### PR TITLE
Make tests work on any machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: build
 	pip install dist/*.tar.gz
 
 develop:
-	pip install -e .
+	pip install -e .[develop]
 
 check:
 	pytest -v tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,15 @@ authors = [
 description = "Remove the yammering from LLM outputs."
 dependencies = [
   "pyparsing",
-  "pytest",
   "pydantic",
   "guidance",
+]
+
+[project.optional-dependencies]
+develop = [
+  "pytest",
+  "build",
+  "gpts",
 ]
 
 [project.urls]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 import os
+import gpts
 import pytest
 from typing import Annotated
 from guidance import block
@@ -6,8 +7,8 @@ from guidance.models import LlamaCpp
 from pydantic import BaseModel, TypeAdapter, StringConstraints
 from minml import types
 
-MODEL_FILE = os.path.expanduser("~/pkg/mistral/mistral-7b-instruct.gguf")
 
+MODEL_FILE = gpts.Mistral().path()
 
 @pytest.fixture(scope="session")
 def model():


### PR DESCRIPTION
This PR 
- Make tests work on any machine using gpts library
- Moves development dependencies into optional dependencies 


If you want to reuse your existing model file, run a quick 
```
mkdir -pv ~/.cache/gpts/mistral/
mv -v ~/pkg/mistral/mistral-7b-instruct.gguf ~/.cache/gpts/mistral/mistral-7b-instruct-v0.2.Q8_0.gguf
```
